### PR TITLE
Potentially malformed byte array encoding of shared secret from ECDH key agreement

### DIFF
--- a/src/main/java/de/gematik/vau/lib/crypto/EllipticCurve.java
+++ b/src/main/java/de/gematik/vau/lib/crypto/EllipticCurve.java
@@ -32,6 +32,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.jce.spec.ECNamedCurveParameterSpec;
 import org.bouncycastle.jce.spec.ECPublicKeySpec;
 import org.bouncycastle.math.ec.ECPoint;
+import org.bouncycastle.util.BigIntegers;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class EllipticCurve {
@@ -105,6 +106,6 @@ public class EllipticCurve {
     ECPublicKeyParameters publicKeyParameters = new ECPublicKeyParameters(ecPoint, domainParams);
 
     BigInteger sharedSecret = ecdhBasicAgreement.calculateAgreement(publicKeyParameters);
-    return sharedSecret.toByteArray();
+    return BigIntegers.asUnsignedByteArray(32, sharedSecret);
   }
 }


### PR DESCRIPTION
We believe that the call to BigInteger's toByteArray() method may result in malformed byte array encodings for some results.
toByteArray() ensures that the output always includes a leading signing bit. However if the most significant bit is already set the output will be prepended by a leading 0x00 byte resulting in 33 bytes output. Furthermore the BigInteger may also be so "small" that only 32 bytes output are returned. This means that depending on the result of the key agreement the resulting byte array may be 33, 32, 31 or even less bytes long. The length however is never checked explicitly and directly used as seed for the KDF which will gladly accept input of any length. We believe that the shared secret byte array should always be of a fixed 32 bytes length representing an unsigned value as proposed by the patch we provide.

on-behalf-of: @achelos-de info@achelos.de