### PR TITLE
Fix method 'countUp' in EncryptionVauKey.

### DIFF
--- a/src/main/java/de/gematik/vau/lib/data/EncryptionVauKey.java
+++ b/src/main/java/de/gematik/vau/lib/data/EncryptionVauKey.java
@@ -32,9 +32,9 @@ public class EncryptionVauKey {
 
     public void countUp() {
         ByteBuffer byteBuffer = ByteBuffer.wrap(counter);
-        int newCount = byteBuffer.getInt() + 1;
+        long newCount = byteBuffer.getLong() + 1;
         byteBuffer = ByteBuffer.allocate(8);
-        byteBuffer.putInt(newCount);
+        byteBuffer.putLong(newCount);
         counter =  byteBuffer.array();
     }
 }

--- a/src/test/java/de/gematik/vau/lib/data/EncryptionVauKeyTest.java
+++ b/src/test/java/de/gematik/vau/lib/data/EncryptionVauKeyTest.java
@@ -1,0 +1,49 @@
+package de.gematik.vau.lib.data;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+class EncryptionVauKeyTest {
+
+    private static final byte[] EXPECTED_BYTES_AFTER_INITIALIZATION = new byte[] {
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+    };
+
+    private static final byte[] EXPECTED_BYTES_AFTER_ONE_COUNT_UP = new byte[] {
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01
+    };
+
+    private static final byte[] EXPECTED_BYTES_AFTER_257_COUNT_UPS = new byte[] {
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01
+    };
+
+    @Test
+    void hasExpectedByteRepresentationAfterInitialization() {
+        EncryptionVauKey encryptionVauKey = new EncryptionVauKey(new byte[]{});
+        byte[] actualCounter = encryptionVauKey.getCounter();
+
+        assertArrayEquals(EXPECTED_BYTES_AFTER_INITIALIZATION, actualCounter);
+    }
+
+    @Test
+    void hasExpectedByteRepresentationAfterOneCountUp() {
+        EncryptionVauKey encryptionVauKey = new EncryptionVauKey(new byte[]{});
+        encryptionVauKey.countUp();
+        byte[] actualCounter = encryptionVauKey.getCounter();
+
+        assertArrayEquals(EXPECTED_BYTES_AFTER_ONE_COUNT_UP, actualCounter);
+    }
+
+    @Test
+    void hasExpectedByteRepresentationAfter257CountUps() {
+        EncryptionVauKey encryptionVauKey = new EncryptionVauKey(new byte[]{});
+        for (int i = 0; i < 257; i++) {
+            encryptionVauKey.countUp();
+        }
+        byte[] actualCounter = encryptionVauKey.getCounter();
+
+        assertArrayEquals(EXPECTED_BYTES_AFTER_257_COUNT_UPS, actualCounter);
+    }
+
+}


### PR DESCRIPTION
The key usage counter in class `EncryptionVauKey` did not work as expected. Calling the method `countUp` once resulted in 0000000100000000, while I expected 0000000000000001. In this PR, I added some unit tests for the `countUp` method and a correction for the `EncryptionVauKey` class.